### PR TITLE
Fix/statefile

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -267,7 +267,10 @@ class Component(ComponentBase):
                 return
 
             new_state = {
-                "component": {STATE_AUTH_ID: self.credentials.get("id", ""), STATE_REFRESH_TOKEN: encrypted_refresh_token}
+                "component": {
+                    STATE_AUTH_ID: self.credentials.get("id", ""),
+                    STATE_REFRESH_TOKEN: encrypted_refresh_token
+                }
             }
             try:
                 self.update_config_state(


### PR DESCRIPTION
Always write the state file to data/out, otherwise, when the job is successful, the state file written via SAPI is overwritten with an empty file.

tested here: https://connection.keboola.com/admin/projects/9382/components/keboola.ex-adform-metadata/1224711400